### PR TITLE
adds trends indicators

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -96,7 +96,7 @@ exports.main = function() {
   // Live enable/disable ticker from options checkbox
   var toggleTicker = function(tickerName, tickerCreator) {
     if ( getBooleanPreference('p' + tickerName) ) { // Enable Ticker
-      if (tickers[tickerName + 'Ticker'] == null) { 
+      if (tickers[tickerName + 'Ticker'] == null) {
         tickers[tickerName + 'Ticker'] = tickerCreator();
       }
     } else if ( tickers[tickerName + 'Ticker'] != null ) { // Disable Ticker if it exists
@@ -187,6 +187,8 @@ exports.main = function() {
         updateTicker();
       }
     });
+    ticker.last = 0;
+    ticker.trend = 0;
     ticker.port.emit("updateStyle", color, font_size, gold_background, silver_background);
     ticker.port.emit("updateContent", latest_content);
     // Default ticker created //
@@ -216,7 +218,7 @@ exports.main = function() {
       {
         ticker_width += 1;
         text_size -= 1;
-      }            
+      }
       ticker_width += (text_size * 8); // Aproximatelt 8 pixels per character (except dots)
       if (currency == "元") { // Yuan character needs extra pixels to be painted
         ticker_width += 10;
@@ -239,12 +241,42 @@ exports.main = function() {
             for (var i = 0; i < json_path.length; i++) { // Parse JSON path
               price = price[json_path[i]];
             }
+            //if (!ticker.trend) { ticker.trend = 0; }
+            slope = (ticker.last>0) ? price/ticker.last - 1 : 0;
+            // decay on the last 10 updates
+            ticker.trend = (0.9 * ticker.trend) + slope;
+            label_slope = '\u2194';
+            label_trend = '\u21d4';
+            if (slope>=0.001) {
+              label_slope = (slope>=0.01) ? '\u219f' : '\u2191';
+            }
+            else if (slope<=-0.001) {
+              label_slope = (slope<=-0.01) ? '\u21a1' : '\u2193';
+            }
+            if (ticker.trend>=0.01) {
+              label_trend = '\u21e7';
+            }
+            else if (ticker.trend<=-0.01) {
+              label_trend = '\u21e9';
+            }
             var round_factor = 100;
             if ( isLitecoin(currency) ) { // Allow more decimals for Litecoin
               round_factor = 10000;
             }
+            // note: display value of trend is divided by 10,
+            // because geometric progression of *0.9 converges to 10.
+            ticker.tooltip = ticker.label + " -- previous: "
+                + (Math.round(ticker.last * round_factor) / round_factor) + currency
+                + " -- trend: " + ((ticker.trend>0) ? "+" : "") + (Math.round(ticker.trend*10000)/1000) + "%";
+            ticker.last = price;
             price = Math.round(price * round_factor) / round_factor;
             latest_content = price + currency;
+            if (getBooleanPreference("show-short-trend")) {
+              latest_content = label_slope + latest_content;
+            }
+            if (getBooleanPreference("show-long-trend")) {
+              latest_content = label_trend + latest_content;
+            }
           }
           ticker.port.emit("updateContent", latest_content);
           updateTickerStyle();
@@ -264,11 +296,11 @@ exports.main = function() {
   var createMtGoxUSDTicker = function() { return createTicker('MtGoxUSD', 'MtGox', '$', '#B43104', "https://data.mtgox.com/api/2/BTCUSD/money/ticker", ['data','last','value']); };
   registerEvents('MtGoxUSD', createMtGoxUSDTicker);
   tickers['MtGoxUSDTicker'] = createMtGoxUSDTicker();
-  
+
   var createBitStampUSDTicker = function() { return createTicker('BitStampUSD', 'BitStamp', '$', '#FF0000', "https://www.bitstamp.net/api/ticker/", ['last']); };
   registerEvents('BitStampUSD', createBitStampUSDTicker);
   tickers['BitStampUSDTicker'] = createBitStampUSDTicker();
-  
+
   var createBTCeUSDTicker = function() { return createTicker('BTCeUSD', 'BTCe', '$', '#FE642E', "https://btc-e.com/api/2/btc_usd/ticker", ['ticker','last']); };
   registerEvents('BTCeUSD', createBTCeUSDTicker);
   tickers['BTCeUSDTicker'] = createBTCeUSDTicker();
@@ -293,11 +325,11 @@ exports.main = function() {
   var createKrakenEURTicker = function() { return createTicker('KrakenEUR', 'Kraken', '€', '#3366FF', "https://api.kraken.com/0/public/Ticker?pair=XBTEUR", ['result','XXBTZEUR','c',0]); };
   registerEvents('KrakenEUR', createKrakenEURTicker);
   tickers['KrakenEURTicker'] = createKrakenEURTicker();
-  
+
   var createCoinDeskEURTicker = function() { return createTicker('CoinDeskEUR', 'CoinDesk', '€', '#000066', "http://api.coindesk.com/v1/bpi/currentprice.json", ['bpi','EUR','rate_float']); };
   registerEvents('CoinDeskEUR', createCoinDeskEURTicker);
   tickers['CoinDeskEURTicker'] = createCoinDeskEURTicker();
-  
+
   // Pound prices //
   var createCoinDeskGBPTicker = function() { return createTicker('CoinDeskGBP', 'CoinDesk', '£', '#088A08', "http://api.coindesk.com/v1/bpi/currentprice.json", ['bpi','GBP','rate_float']); };
   registerEvents('CoinDeskGBP', createCoinDeskGBPTicker);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,18 @@
     "value": true
   },
   {
+    "name": "show-long-trend",
+    "title": "Show long-time trend",
+    "type": "bool",
+    "value": true
+  },
+  {
+    "name": "show-short-trend",
+    "title": "Show short-time trend (since last update)",
+    "type": "bool",
+    "value": true
+  },
+  {
     "name": "pMtGoxUSD",
     "title": "Show MtGox USD ($) ticker?",
     "type": "bool",


### PR DESCRIPTION
adds long and short trend computation (in tooltips), and optional markers in front of the value. Short trend is just the diff with the last value. Long trend is computed with a 0.9 decay of the sum. Markers are disabled by default and can be enabled individually in preferences. Tooltips is added to display more information about the changes.
