### PR TITLE
Label takes in account the font size

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -219,10 +219,10 @@ exports.main = function() {
       var text_size = latest_content.toString().length;
       if (latest_content.toString().indexOf('.') != -1)
       {
-        ticker_width += 1;
+        ticker_width += 4;
         text_size -= 1;
       }
-      ticker_width += (text_size * 8); // Aproximatelt 8 pixels per character (except dots)
+      ticker_width += (text_size * font_size * 9 / 14); // Aproximatelt 8 pixels per character (except dots)
       if (currency == "元") { // Yuan character needs extra pixels to be painted
         ticker_width += 10;
       }


### PR DESCRIPTION
The default label width is not pretty on my machine. I have to change the font size and ticker spacing to get a nice display. This patch tweaks the widget width computation base on text and takes in account the font size. It works for me, but might not work for your browser, so feel free to change or reject the patch. Cheers.
