### PR TITLE
replaces non-ascii currency character with the explicit unicode escape

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -165,13 +165,13 @@ exports.main = function() {
     var color = getStringPreference("p" + id + "Color");
     var gold_background = getBooleanPreference("gold-background");
     var silver_background = getBooleanPreference("silver-background");
-    var label_currency = currency;
+    var label_currency = currency+'/\u0243'; // Ƀ
     if ( isLitecoin(id) ) { // Litecoin can't have the gold Bitcoin background
       gold_background = false;
-      if ( currency != 'Ł' ) { // Litecoin pair
-        label_currency = currency + " / Ł";
+      if ( currency != '\u0141' ) { // Litecoin pair
+        label_currency = currency + "/\u0141";
       } else { // Default pair for Litecoin
-        label_currency = "Bitcoin / Ł";
+        label_currency = "\u0243/\u0141"; // Ƀ/Ł
       }
     } else {
       silver_background = false; // Bitcoin can't have the silver Litecoin background
@@ -223,7 +223,7 @@ exports.main = function() {
         text_size -= 1;
       }
       ticker_width += (text_size * 8); // Aproximatelt 8 pixels per character (except dots)
-      if (currency == "元") { // Yuan character needs extra pixels to be painted
+      if (currency == "\u5143") { // Yuan character needs extra pixels to be painted
         ticker_width += 10;
       }
       ticker.width = ticker_width;
@@ -286,44 +286,44 @@ exports.main = function() {
   registerEvents('CoinDeskUSD', createCoinDeskUSDTicker);
   tickers['CoinDeskUSDTicker'] = createCoinDeskUSDTicker();
 
-  // Euro prices //
-  var createMtGoxEURTicker = function() { return createTicker('MtGoxEUR', 'MtGox', '€', '#807AE2', "https://data.mtgox.com/api/2/BTCEUR/money/ticker", ['data','last','value']); };
+  // Euro prices // €
+  var createMtGoxEURTicker = function() { return createTicker('MtGoxEUR', 'MtGox', '\u20ac', '#807AE2', "https://data.mtgox.com/api/2/BTCEUR/money/ticker", ['data','last','value']); };
   registerEvents('MtGoxEUR', createMtGoxEURTicker);
   tickers['MtGoxEURTicker'] = createMtGoxEURTicker();
 
-  var createBTCeEURTicker = function() { return createTicker('BTCeEUR', 'BTCe', '€', '#013ADF', "https://btc-e.com/api/2/btc_eur/ticker", ['ticker','last']); };
+  var createBTCeEURTicker = function() { return createTicker('BTCeEUR', 'BTCe', '\u20ac', '#013ADF', "https://btc-e.com/api/2/btc_eur/ticker", ['ticker','last']); };
   registerEvents('BTCeEUR', createBTCeEURTicker);
   tickers['BTCeEURTicker'] = createBTCeEURTicker();
 
-  var createKrakenEURTicker = function() { return createTicker('KrakenEUR', 'Kraken', '€', '#3366FF', "https://api.kraken.com/0/public/Ticker?pair=XBTEUR", ['result','XXBTZEUR','c',0]); };
+  var createKrakenEURTicker = function() { return createTicker('KrakenEUR', 'Kraken', '\u20ac', '#3366FF', "https://api.kraken.com/0/public/Ticker?pair=XBTEUR", ['result','XXBTZEUR','c',0]); };
   registerEvents('KrakenEUR', createKrakenEURTicker);
   tickers['KrakenEURTicker'] = createKrakenEURTicker();
 
-  var createCoinDeskEURTicker = function() { return createTicker('CoinDeskEUR', 'CoinDesk', '€', '#000066', "http://api.coindesk.com/v1/bpi/currentprice.json", ['bpi','EUR','rate_float']); };
+  var createCoinDeskEURTicker = function() { return createTicker('CoinDeskEUR', 'CoinDesk', '\u20ac', '#000066', "http://api.coindesk.com/v1/bpi/currentprice.json", ['bpi','EUR','rate_float']); };
   registerEvents('CoinDeskEUR', createCoinDeskEURTicker);
   tickers['CoinDeskEURTicker'] = createCoinDeskEURTicker();
 
-  // Pound prices //
-  var createCoinDeskGBPTicker = function() { return createTicker('CoinDeskGBP', 'CoinDesk', '£', '#088A08', "http://api.coindesk.com/v1/bpi/currentprice.json", ['bpi','GBP','rate_float']); };
+  // Pound prices // £
+  var createCoinDeskGBPTicker = function() { return createTicker('CoinDeskGBP', 'CoinDesk', '\u00a3', '#088A08', "http://api.coindesk.com/v1/bpi/currentprice.json", ['bpi','GBP','rate_float']); };
   registerEvents('CoinDeskGBP', createCoinDeskGBPTicker);
   tickers['CoinDeskGBPTicker'] = createCoinDeskGBPTicker();
 
-  // Yen prices //
-  var createMtGoxJPYTicker = function() { return createTicker('MtGoxJPY', 'MtGox', '¥', '#04B4AE', "https://data.mtgox.com/api/2/BTCJPY/money/ticker", ['data','last','value']); };
+  // Yen prices // ¥
+  var createMtGoxJPYTicker = function() { return createTicker('MtGoxJPY', 'MtGox', '\u00a5', '#04B4AE', "https://data.mtgox.com/api/2/BTCJPY/money/ticker", ['data','last','value']); };
   registerEvents('MtGoxJPY', createMtGoxJPYTicker);
   tickers['MtGoxJPYTicker'] = createMtGoxJPYTicker();
 
-  // Yuan prices //
-  var createMtGoxCNYTicker = function() { return createTicker('MtGoxCNY', 'MtGox', '元', '#A901DB', "https://data.mtgox.com/api/2/BTCCNY/money/ticker", ['data','last','value']); };
+  // Yuan prices // 元
+  var createMtGoxCNYTicker = function() { return createTicker('MtGoxCNY', 'MtGox', '\u5143', '#A901DB', "https://data.mtgox.com/api/2/BTCCNY/money/ticker", ['data','last','value']); };
   registerEvents('MtGoxCNY', createMtGoxCNYTicker);
   tickers['MtGoxCNYTicker'] = createMtGoxCNYTicker();
 
-  var createBTCChinaCNYTicker = function() { return createTicker('BTCChinaCNY', 'BTCChina', '元', '#DF01D7', "https://vip.btcchina.com/bc/ticker", ['ticker','last']); };
+  var createBTCChinaCNYTicker = function() { return createTicker('BTCChinaCNY', 'BTCChina', '\u5143', '#DF01D7', "https://vip.btcchina.com/bc/ticker", ['ticker','last']); };
   registerEvents('BTCChinaCNY', createBTCChinaCNYTicker);
   tickers['BTCChinaCNYTicker'] = createBTCChinaCNYTicker();
 
-  // Litecoin prices //
-  var createBTCeLitecoinTicker = function() { return createTicker('BTCeLitecoin', 'BTCe', 'Ł', '#013ADF', "https://btc-e.com/api/2/ltc_btc/ticker", ['ticker','last']); };
+  // Litecoin prices // Ł
+  var createBTCeLitecoinTicker = function() { return createTicker('BTCeLitecoin', 'BTCe', '\u0141', '#013ADF', "https://btc-e.com/api/2/ltc_btc/ticker", ['ticker','last']); };
   registerEvents('BTCeLitecoin', createBTCeLitecoinTicker);
   tickers['BTCeLitecoinTicker'] = createBTCeLitecoinTicker();
 
@@ -331,11 +331,11 @@ exports.main = function() {
   registerEvents('BTCeLitecoinUSD', createBTCeLitecoinUSDTicker);
   tickers['BTCeLitecoinUSDTicker'] = createBTCeLitecoinUSDTicker();
 
-  var createVircurexLitecoinTicker = function() { return createTicker('VircurexLitecoin', 'Vircurex', 'Ł', '#0B0B3B', "https://vircurex.com/api/get_last_trade.json?base=LTC&alt=BTC", ['value']); };
+  var createVircurexLitecoinTicker = function() { return createTicker('VircurexLitecoin', 'Vircurex', '\u0141', '#0B0B3B', "https://vircurex.com/api/get_last_trade.json?base=LTC&alt=BTC", ['value']); };
   registerEvents('VircurexLitecoin', createVircurexLitecoinTicker);
   tickers['VircurexLitecoinTicker'] = createVircurexLitecoinTicker();
 
-  var createKrakenLitecoinTicker = function() { return createTicker('KrakenLitecoin', 'Kraken', 'Ł', '#000066', "https://api.kraken.com/0/public/Ticker?pair=XBTLTC", ['result','XXBTXLTC','c',0]); };
+  var createKrakenLitecoinTicker = function() { return createTicker('KrakenLitecoin', 'Kraken', '\u0141', '#000066', "https://api.kraken.com/0/public/Ticker?pair=XBTLTC", ['result','XXBTXLTC','c',0]); };
   registerEvents('KrakenLitecoin', createKrakenLitecoinTicker);
   tickers['KrakenLitecoinTicker'] = createKrakenLitecoinTicker();
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   {
     "name": "pMtGoxUSD",
-    "title": "Show MtGox USD ($) ticker?",
+    "title": "Show MtGox USD ($/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -59,7 +59,7 @@
   },
   {
     "name": "pBitStampUSD",
-    "title": "Show BitStamp USD ($) ticker?",
+    "title": "Show BitStamp USD ($/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -70,7 +70,7 @@
   },
   {
     "name": "pBTCeUSD",
-    "title": "Show BTCe USD ($) ticker?",
+    "title": "Show BTCe USD ($/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -81,7 +81,7 @@
   },
   {
     "name": "pKrakenUSD",
-    "title": "Show Kraken USD ($) ticker?",
+    "title": "Show Kraken USD ($/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -92,7 +92,7 @@
   },
   {
     "name": "pCoinDeskUSD",
-    "title": "Show CoinDesk USD ($) ticker?",
+    "title": "Show CoinDesk USD ($/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -103,7 +103,7 @@
   },
   {
     "name": "pMtGoxEUR",
-    "title": "Show MtGox EUR (€) ticker?",
+    "title": "Show MtGox EUR (\u20ac/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -114,7 +114,7 @@
   },
   {
     "name": "pBTCeEUR",
-    "title": "Show BTCe EUR (€) ticker?",
+    "title": "Show BTCe EUR (\u20ac/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -125,7 +125,7 @@
   },
   {
     "name": "pKrakenEUR",
-    "title": "Show Kraken EUR (€) ticker?",
+    "title": "Show Kraken EUR (\u20ac/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -136,7 +136,7 @@
   },
   {
     "name": "pCoinDeskEUR",
-    "title": "Show CoinDesk EUR (€) ticker?",
+    "title": "Show CoinDesk EUR (\u20ac/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -147,7 +147,7 @@
   },
   {
     "name": "pCoinDeskGBP",
-    "title": "Show CoinDesk GBP (£) ticker?",
+    "title": "Show CoinDesk GBP (\u00a3/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -158,7 +158,7 @@
   },
   {
     "name": "pMtGoxJPY",
-    "title": "Show MtGox JPY (¥) ticker?",
+    "title": "Show MtGox JPY (\u00a5/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -169,7 +169,7 @@
   },
   {
     "name": "pMtGoxCNY",
-    "title": "Show MtGox CNY (元) ticker?",
+    "title": "Show MtGox CNY (\u5143/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -180,7 +180,7 @@
   },
   {
     "name": "pBTCChinaCNY",
-    "title": "Show BTCChina CNY (元) ticker?",
+    "title": "Show BTCChina CNY (\u5143/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -191,7 +191,7 @@
   },
   {
     "name": "pBTCeLitecoin",
-    "title": "Show BTCe Bitcoin/Litecoin (Ł) ticker?",
+    "title": "Show BTCe Bitcoin/Litecoin (\u0243/\u0141) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -202,7 +202,7 @@
   },
   {
     "name": "pBTCeLitecoinUSD",
-    "title": "Show BTCe USD/Litecoin (Ł) ticker?",
+    "title": "Show BTCe USD/Litecoin (\u0141/\u0243) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -213,7 +213,7 @@
   },
   {
     "name": "pVircurexLitecoin",
-    "title": "Show Vircurex Bitcoin/Litecoin (Ł) ticker?",
+    "title": "Show Vircurex Bitcoin/Litecoin (\u0243/\u0141) ticker?",
     "type": "bool",
     "value": true
   },{
@@ -224,7 +224,7 @@
   },
   {
     "name": "pKrakenLitecoin",
-    "title": "Show Kraken Litecoin/Bitcoin (Ł) ticker? (inverted price)",
+    "title": "Show Kraken Litecoin/Bitcoin (\u0141/\u0243) ticker? (inverted price)",
     "type": "bool",
     "value": true
   },{


### PR DESCRIPTION
It's generally considered good practice to escape non-ascii characters in sources, to avoid changes that are invisible in some editors. (My editor doesn't display the Yuan character properly, for instance.)

This patch doesn't change the behavior of the add-on, just makes the sources encoding explicit.
