### PR TITLE
Replace BitFinex with Poloniex for Dash

### DIFF
--- a/data/data-providers.json
+++ b/data/data-providers.json
@@ -72,8 +72,8 @@
   "PoloniexBitcoindark": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BTCD", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BTCD", "last"]},
 
   "PoloniexMonero": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"XMR", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_XMR", "last"]},
-  "BitFinexDashBTC": { "exchangeName":"BitFinex", "currency":"\u0243",  "baseCurrency":"DASH", "url":"https://api.bitfinex.com/v1/ticker/drkbtc", "jsonPath":["last_price"]},
-  "BitFinexDashUSD": { "exchangeName":"BitFinex", "currency":"$",  "baseCurrency":"DASH", "url":"https://api.bitfinex.com/v1/ticker/drkusd", "jsonPath":["last_price"]},
+
+  "PoloniexDash": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"DASH", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_DASH", "last"]},
 
   "PoloniexBurst": { "exchangeName":"Poloniex", "currency":"\u0243",  "baseCurrency":"BURST", "url":"https://poloniex.com/public?command=returnTicker", "jsonPath":["BTC_BURST", "last"]},
 

--- a/package.json
+++ b/package.json
@@ -636,24 +636,13 @@
     "value": "#413ADF"
   },
   {
-    "name": "pBitFinexDashBTC",
-    "title": "BitFinex Bitcoin/Dash (\u0243/DASH) ticker?",
+    "name": "pPoloniexDash",
+    "title": "Poloniex Bitcoin/Dash (\u0243/DASH) ticker?",
     "type": "bool",
     "value": false
   },{
-    "name": "pBitFinexDashBTCColor",
-    "title": "BitFinex Bitcoin/Dash Ticker color",
-    "type": "color",
-    "value": "#1c75bc"
-  },
-  {
-    "name": "pBitFinexDashUSD",
-    "title": "BitFinex USD/Dash ($/DASH) ticker?",
-    "type": "bool",
-    "value": false
-  },{
-    "name": "pBitFinexDashUSDColor",
-    "title": "BitFinex USD/Dash Ticker color",
+    "name": "pPoloniexDashColor",
+    "title": "Poloniex Bitcoin/Dash Ticker color",
     "type": "color",
     "value": "#1c75bc"
   },


### PR DESCRIPTION
Dash is no longer available on BitFinex and since Cryptsy is gone too there is no actual source for Dash in the extension anymore. This PR should fix it by removing BitFinex and adding Poloniex ticker instead.